### PR TITLE
Added documentation on redirecting to /signin and /signup for partners

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ You can also specifically redirect users to the /signin or /signup endpoint spec
 
 **Sign in**
 ```
-https://partners.checkr.com/authorize/:client_id/signin?scope=read_write&ref=dashboard
+https://partners.checkr.com/authorize/:client_id/signin?scope=read_write
 ```
 
 **Sign up**
 ```
-https://partners.checkr.com/authorize/:client_id/signup?scope=read_write&ref=dashboard
+https://partners.checkr.com/authorize/:client_id/signup?scope=read_write
 ```
 
 To prevent CSRF attacks, you can also use the `state` parameter, passing along a unique token as the value. We’ll include the `state` you gave us when we redirect back.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ With these pieces of information on hand, you’re ready to have your end users 
 https://dashboard.checkr.com/oauth/authorize/:client_id?scope=read_write
 ```
 
+You can also specifically redirect users to the /signin or /signup endpoint specifically depending on whether you know they have already set up an account with Checkr. The URLs for both options are as follows:
+
+**Sign in**
+```
+https://partners.checkr.com/authorize/:client_id/signin?scope=read_write&ref=dashboard
+```
+
+**Sign up**
+```
+https://partners.checkr.com/authorize/:client_id/signup?scope=read_write&ref=dashboard
+```
+
 To prevent CSRF attacks, you can also use the `state` parameter, passing along a unique token as the value. We’ll include the `state` you gave us when we redirect back.
 
 Here is how this may look:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ With these pieces of information on hand, you’re ready to have your end users 
 https://dashboard.checkr.com/oauth/authorize/:client_id?scope=read_write
 ```
 
-You can also specifically redirect users to the /signin or /signup endpoint specifically depending on whether you know they have already set up an account with Checkr. The URLs for both options are as follows:
+You can also specifically redirect users to the "/signin" or "/signup" endpoint specifically depending on whether you know they have already set up an account with Checkr. The URLs for both options are as follows:
 
 **Sign in**
 ```


### PR DESCRIPTION
I could've just edited this inline, but I was on a high from my recent pull request on Friday. Added documentation so partners know they can redirect to the /signin & /signup flows. Relevant for BD as they onboard new partners with oAuth integrations.